### PR TITLE
fix(db): treat deadlock as expected event

### DIFF
--- a/src/Console/Commands/LlockFree.php
+++ b/src/Console/Commands/LlockFree.php
@@ -43,8 +43,16 @@ class LlockFree extends Command
 
         try {
             Lock::free($this->argument('name'));
+            // only log a note since this is an expected event (but it is still an error as far as freeing the lock)
+        } catch (\Illuminate\Database\QueryException $e) {
+            Log::debug('Lock free already in progress...');
+            
+            exit (Lock::ERROR);
+
         } catch (\Exception $e) {
-            // TODO catch database exceptions, etc. here?
+            Log::error($e->getMessage() . " exception freeing lock ${name}: " . $e->getTraceAsString());
+
+            exit (Lock::ERROR);
         }
     }
 }

--- a/src/Console/Commands/LlockSet.php
+++ b/src/Console/Commands/LlockSet.php
@@ -88,9 +88,14 @@ class LlockSet extends Command
 
                 exit(Lock::SUCCESS);
             }
-        
+        // only log a note since this is an expected event (but it is still an error as far as getting the lock)
+        } catch (\Illuminate\Database\QueryException $e) {
+            Log::debug('Lock already in progress...');
+
+            exit (Lock::ERROR);
+
         } catch (\Exception $e) {
-            Log::error("Exception obtaining lock ${name}: " . $e->getTraceAsString());
+            Log::error($e->getMessage() . " exception obtaining lock ${name}: " . $e->getTraceAsString());
 
             exit (Lock::ERROR);
         }


### PR DESCRIPTION
Just means we have two lock set/free requests at the *exact* same time.